### PR TITLE
feat: include negative prompts in logs and EXIF metadata

### DIFF
--- a/imaginairy/schema.py
+++ b/imaginairy/schema.py
@@ -165,18 +165,28 @@ class ImaginePrompt:
             return self.prompts[0].text
         return "|".join(str(p) for p in self.prompts)
 
+    @property
+    def negative_prompt_text(self):
+        if len(self.negative_prompt) == 1:
+            return self.negative_prompt[0].text
+        return "|".join(str(p) for p in self.negative_prompt)
+
     def prompt_description(self):
         return (
             f'"{self.prompt_text}" {self.width}x{self.height}px '
+            f'negative-prompt:"{self.negative_prompt_text}" '
             f"seed:{self.seed} prompt-strength:{self.prompt_strength} steps:{self.steps} sampler-type:{self.sampler_type}"
         )
 
     def as_dict(self):
         prompts = [(p.weight, p.text) for p in self.prompts]
+        negative_prompts = [(p.weight, p.text) for p in self.negative_prompt]
         return {
-            "software": "imaginairy",
+            "software": "imaginAIry",
+            "model": self.model,
             "prompts": prompts,
             "prompt_strength": self.prompt_strength,
+            "negative_prompt": negative_prompts,
             "init_image": str(self.init_image),
             "init_image_strength": self.init_image_strength,
             "seed": self.seed,


### PR DESCRIPTION
To improve reproducibility, I've added the negative prompts into the logs and EXIF metadata. The model was already placed into the Software field, but I thought it would be good to also include it into the JSON string. This will enable future deserialization from the EXIF data.

## Logs
```
Generating 🖼  19/1000: "two young children (1 male) (1 female), with thick dark hair and light skin, blue eyes, making a plane with legos, comic book, marvel, superflat, dc comics, artistic rendering, alternate album cover, graphic novel, promotional art, deviantart contest winner, centered composition" 512x512px negative-prompt:"((((text)))), (logo), disfigured, fused fingers, extra limbs, realistic, photo, 3d render, 3 eyes, nsfw, grain, cropped, out of frame" seed:480030103 prompt-strength:7.5 steps:75 sampler-type:k_dpmpp_2m
100% | 75/75 [00:33<00:00,  2.25it/s]
    Image Generated. Timings: conditioning:0.31s sampling:33.37s safety-filter:0.40s total:34.47s
    🖼  [generated] saved to: ./outputs/SD-2.1/generated/000448_480030103_kdpmpp2m75_PS7.5_two_young_children_1_male_1_female_,_with_thick_dark_hair_and_light_skin,_blue_eyes,_making_a_plane_with_legos,_comic_book,_marvel_[generated].jpg
```

## EXIF data
```
$ exiftool 000448_480030103_kdpmpp2m75_PS7.5_two_young_children_1_male_1_female_,_with_thick_dark_hair_and_light_skin,_blue_eyes,_making_a_plane_with_legos,_comic_book,_marvel_\[generated\].jpg
...
Image Description               : "two young children (1 male) (1 female), with thick dark hair and light skin, blue eyes, making a plane with legos, comic book, marvel, superflat, dc comics, artistic rendering, alternate album cover, graphic novel, promotional art, deviantart contest winner, centered composition" 512x512px negative-prompt:"((((text)))), (logo), disfigured, fused fingers, extra limbs, realistic, photo, 3d render, 3 eyes, nsfw, grain, cropped, out of frame" seed:480030103 prompt-strength:7.5 steps:75 sampler-type:k_dpmpp_2m
Software                        : Imaginairy / Stable Diffusion SD-2.1
User Comment                    : {"prompt": {"software": "imaginAIry", "model": "SD-2.1", "prompts": [[1, "two young children (1 male) (1 female), with thick dark hair and light skin, blue eyes, making a plane with legos, comic book, marvel, superflat, dc comics, artistic rendering, alternate album cover, graphic novel, promotional art, deviantart contest winner, centered composition"]], "prompt_strength": 7.5, "negative_prompt": [[1, "((((text)))), (logo), disfigured, fused fingers, extra limbs, realistic, photo, 3d render, 3 eyes, nsfw, grain, cropped, out of frame"]], "init_image": "None", "init_image_strength": 0.6, "seed": 480030103, "steps": 75, "height": 512, "width": 512, "upscale": false, "fix_faces": false, "sampler_type": "k_dpmpp_2m"}}
...
```