### PR TITLE
fix: add png handling for LazyLoadingImage

### DIFF
--- a/imaginairy/enhancers/describe_image_blip.py
+++ b/imaginairy/enhancers/describe_image_blip.py
@@ -36,6 +36,7 @@ def blip_model():
 
 def generate_caption(image, min_length=30):
     """Given an image, return a caption."""
+    image = image.convert("RGB")
     gpu_image = (
         transforms.Compose(
             [

--- a/imaginairy/schema.py
+++ b/imaginairy/schema.py
@@ -55,7 +55,7 @@ class LazyLoadingImage:
             return getattr(self._img, key)
 
         if self._lazy_filepath:
-            self._img = Image.open(self._lazy_filepath).convert('RGB')
+            self._img = Image.open(self._lazy_filepath)
             logger.debug(
                 f"Loaded input 🖼  of size {self._img.size} from {self._lazy_filepath}"
             )

--- a/imaginairy/schema.py
+++ b/imaginairy/schema.py
@@ -55,7 +55,7 @@ class LazyLoadingImage:
             return getattr(self._img, key)
 
         if self._lazy_filepath:
-            self._img = Image.open(self._lazy_filepath)
+            self._img = Image.open(self._lazy_filepath).convert('RGB')
             logger.debug(
                 f"Loaded input 🖼  of size {self._img.size} from {self._lazy_filepath}"
             )


### PR DESCRIPTION
Loading png images will cause the following error since PIL loads png images in RGBA mode.

```python
  File "/Users/sunjiaming/miniconda3/lib/python3.8/site-packages/torchvision/transforms/functional_tensor.py", line 940, in normalize
    return tensor.sub_(mean).div_(std)
RuntimeError: The size of tensor a (4) must match the size of tensor b (3) at non-singleton dimension 0
```

