### PR TITLE
Handle model paths with illegal characters in filename

### DIFF
--- a/imaginairy/model_manager.py
+++ b/imaginairy/model_manager.py
@@ -1,6 +1,7 @@
 import gc
 import logging
 import os
+import re
 import sys
 import urllib.parse
 from functools import wraps
@@ -288,6 +289,8 @@ def get_cached_url_path(url, category=None):
     if category:
         dest = os.path.join(dest, category)
     os.makedirs(dest, exist_ok=True)
+    # Replace possibly illegal destination path characters
+    filename = re.sub('[*<>:"|?]', '_', filename)
     dest_path = os.path.join(dest, filename)
     if os.path.exists(dest_path):
         return dest_path

--- a/imaginairy/model_manager.py
+++ b/imaginairy/model_manager.py
@@ -289,11 +289,19 @@ def get_cached_url_path(url, category=None):
     if category:
         dest = os.path.join(dest, category)
     os.makedirs(dest, exist_ok=True)
+
     # Replace possibly illegal destination path characters
-    filename = re.sub('[*<>:"|?]', '_', filename)
-    dest_path = os.path.join(dest, filename)
+    safe_filename = re.sub('[*<>:"|?]', "_", filename)
+    dest_path = os.path.join(dest, safe_filename)
     if os.path.exists(dest_path):
         return dest_path
+
+    # check if it's saved at previous path and rename it
+    old_dest_path = os.path.join(dest, filename)
+    if os.path.exists(old_dest_path):
+        os.rename(old_dest_path, dest_path)
+        return dest_path
+
     r = requests.get(url)  # noqa
 
     with open(dest_path, "wb") as f:


### PR DESCRIPTION
If a model has a remote filename with characters that might not be supported on the local cache filesystem, replace them during translation of URL to cached file path.

Closes #202.