### PR TITLE
perf: improve startup time by doing some imports lazily

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
         python-version: 3.9
     - name: Install dependencies
       run: |
-        python -m pip install --disable-pip-version-check black isort
+        python -m pip install --disable-pip-version-check black==22.12.0 isort==5.11.4
     - name: Autoformatter
       run: |
         black --diff .

--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ docker run -it --gpus all -v $HOME/.cache/huggingface:/root/.cache/huggingface -
 
 ## ChangeLog
 
+- perf: cli now has minimal overhead such that `aimg --help` runs in ~650ms instead of ~3400ms
+
 **8.3.1**
 - fix: init-image-strength type
 

--- a/imaginairy/__init__.py
+++ b/imaginairy/__init__.py
@@ -1,19 +1,12 @@
-import os.path
+import os
 
 # tells pytorch to allow MPS usage (for Mac M1 compatibility)
 os.putenv("PYTORCH_ENABLE_MPS_FALLBACK", "1")
-import PIL.Image  # noqa
 
 from .api import imagine, imagine_image_files  # noqa
-from .enhancers.describe_image_blip import generate_caption  # noqa
 from .schema import (  # noqa
     ImaginePrompt,
     ImagineResult,
     LazyLoadingImage,
     WeightedPrompt,
 )
-from .version import __version__  # noqa
-
-# https://stackoverflow.com/questions/71738218/module-pil-has-not-attribute-resampling
-if not hasattr(PIL.Image, "Resampling"):  # Pillow<9.0
-    PIL.Image.Resampling = PIL.Image

--- a/imaginairy/bin/aimg
+++ b/imaginairy/bin/aimg
@@ -1,0 +1,6 @@
+#!/bin/env python
+# -*- coding: utf-8 -*-
+
+if __name__ == "__main__":
+    from imaginairy import cmds
+    cmds.aimg()

--- a/imaginairy/bin/imagine
+++ b/imaginairy/bin/imagine
@@ -1,0 +1,6 @@
+#!/bin/env python
+# -*- coding: utf-8 -*-
+
+if __name__ == "__main__":
+    from imaginairy import cmds
+    cmds.imagine_cmd()

--- a/imaginairy/config.py
+++ b/imaginairy/config.py
@@ -142,3 +142,18 @@ MODEL_CONFIG_SHORTCUTS["openjourney"] = MODEL_CONFIG_SHORTCUTS["openjourney-v2"]
 MODEL_CONFIG_SHORTCUTS["oj"] = MODEL_CONFIG_SHORTCUTS["openjourney-v2"]
 
 MODEL_SHORT_NAMES = sorted(MODEL_CONFIG_SHORTCUTS.keys())
+
+SAMPLER_TYPE_OPTIONS = [
+    "plms",
+    "ddim",
+    "k_dpm_fast",
+    "k_dpm_adaptive",
+    "k_lms",
+    "k_dpm_2",
+    "k_dpm_2_a",
+    "k_dpmpp_2m",
+    "k_dpmpp_2s_a",
+    "k_euler",
+    "k_euler_a",
+    "k_heun",
+]

--- a/imaginairy/debug_info.py
+++ b/imaginairy/debug_info.py
@@ -3,13 +3,14 @@ import sys
 
 import torch
 
-from imaginairy import __version__
 from imaginairy.utils import get_device, get_hardware_description
+from imaginairy.version import get_version
 
 
 def get_debug_info():
+
     data = {
-        "imaginairy_version": __version__,
+        "imaginairy_version": get_version(),
         "imaginairy_path": os.path.dirname(__file__),
         "python_version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
         "python_installation_path": sys.executable,

--- a/imaginairy/log_utils.py
+++ b/imaginairy/log_utils.py
@@ -4,12 +4,6 @@ import re
 import time
 import warnings
 
-import torch
-from pytorch_lightning import _logger as pytorch_logger
-from torchvision.transforms import ToPILImage
-from transformers.modeling_utils import logger as modeling_logger
-from transformers.utils.logging import _configure_library_root_logger
-
 _CURRENT_LOGGING_CONTEXT = None
 
 logger = logging.getLogger(__name__)
@@ -159,6 +153,9 @@ class ImageLoggingContext:
     def log_img(self, img, description):
         if not self.debug_img_callback:
             return
+        import torch
+        from torchvision.transforms import ToPILImage
+
         self.image_count += 1
         if isinstance(img, torch.Tensor):
             img = ToPILImage()(img.squeeze().cpu().detach())
@@ -200,6 +197,8 @@ def filesafe_text(t):
 
 
 def conditioning_to_img(conditioning):
+    from torchvision.transforms import ToPILImage
+
     return ToPILImage()(conditioning)
 
 
@@ -252,6 +251,9 @@ def configure_logging(level="INFO"):
 
 
 def disable_transformers_custom_logging():
+    from transformers.modeling_utils import logger as modeling_logger
+    from transformers.utils.logging import _configure_library_root_logger
+
     _configure_library_root_logger()
     _logger = modeling_logger.parent
     _logger.handlers = []
@@ -263,6 +265,8 @@ def disable_transformers_custom_logging():
 
 
 def disable_pytorch_lighting_custom_logging():
+    from pytorch_lightning import _logger as pytorch_logger
+
     try:
         from pytorch_lightning.utilities.seed import log  # noqa
 

--- a/imaginairy/safety.py
+++ b/imaginairy/safety.py
@@ -6,13 +6,9 @@ from diffusers.pipelines.stable_diffusion import safety_checker as safety_checke
 from transformers import AutoFeatureExtractor
 
 from imaginairy.enhancers.blur_detect import is_blurry
+from imaginairy.schema import SafetyMode
 
 logger = logging.getLogger(__name__)
-
-
-class SafetyMode:
-    STRICT = "strict"
-    RELAXED = "relaxed"
 
 
 class SafetyResult:

--- a/imaginairy/version.py
+++ b/imaginairy/version.py
@@ -1,6 +1,7 @@
-from importlib.metadata import PackageNotFoundError, version
+def get_version():
+    from importlib.metadata import PackageNotFoundError, version
 
-try:
-    __version__ = version("imaginairy")
-except PackageNotFoundError:
-    __version__ = None
+    try:
+        return version("imaginairy")
+    except PackageNotFoundError:
+        return None

--- a/setup.py
+++ b/setup.py
@@ -16,16 +16,12 @@ setup(
         "Source": "https://github.com/brycedrennan/imaginAIry",
     },
     packages=find_packages(include=("imaginairy", "imaginairy.*")),
-    entry_points={
-        "console_scripts": [
-            "imagine=imaginairy.cmds:imagine_cmd",
-            "aimg=imaginairy.cmds:aimg",
-        ],
-    },
+    scripts=["imaginairy/bin/aimg", "imaginairy/bin/imagine"],
     package_data={
         "imaginairy": [
             "configs/*.yaml",
             "data/*.*",
+            "bin/*.*",
             "enhancers/phraselists/*.txt",
             "vendored/clip/*.txt.gz",
             "vendored/clipseg/*.pth",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,6 @@
+from imaginairy import config
+from imaginairy.samplers import SAMPLER_TYPE_OPTIONS
+
+
+def test_sampler_options():
+    assert set(config.SAMPLER_TYPE_OPTIONS) == set(SAMPLER_TYPE_OPTIONS)

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ format = pylint
 skip = */.tox/*,*/.env/*,build/*,*/downloads/*,other/*,prolly_delete/*,downloads/*,imaginairy/vendored/*,testing_support/vastai_cli_official.py,.eggs/*
 linters = pylint,pycodestyle,pyflakes,mypy
 ignore =
-    Z999,C0103,C0301,C0302,C0114,C0115,C0116,
+    Z999,C0103,C0301,C0302,C0114,C0115,C0116,C0415,
     Z999,D100,D101,D102,D103,D105,D106,D107,D200,D202,D203,D205,D212,D400,D401,D406,D407,D413,D415,D417,
     Z999,E203,E501,E1101,E1131,E1135,E1136,
     Z999,R0901,R0902,R0903,R0904,R0193,R0912,R0913,R0914,R0915,R1702,


### PR DESCRIPTION
just running `aimg --help` or `aimg --version` was very slow due to all the imports being brought in eagerly

Before changes `aimg --help`
`2.24s user 4.05s system 184% cpu 3.416 total`

After changes:
`0.04s user 0.02s system 8% cpu 0.625 total`

Used `PYTHONPROFILEIMPORTTIME=1 aimg --help` to find time consuming imports.

Also switched to using `scripts` instead of `entrypoints` since the scripts are much faster.

Made duplicate SAMPLER_TYPE_OPTIONS that can be loaded without loading all the samplers themselves.

Likely a breaking change - not sure.