### PR TITLE
Removing stray space from readme at inopportune location

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ When writing strength modifiers keep in mind that pixel values are between 0 and
 
 ```bash
 >> imagine \
-    --init-image pearl_earring.jpg \ 
+    --init-image pearl_earring.jpg \
     --mask-prompt "face AND NOT (bandana OR hair OR blue fabric){*6}" \
     --mask-mode keep \
     --init-image-strength .2 \


### PR DESCRIPTION
In the multiline example with the "girl with the pearl earring" was a stray space. This led to following error:

```
...
    "a modern female president" "a female robot" "a female doctor" "a female firefighter"
/usr/lib/python3/dist-packages/pkg_resources/__init__.py:116: PkgResourcesDeprecationWarning: 1.1build1 is an invalid version and will not be supported in a future release
  warnings.warn(
/usr/lib/python3/dist-packages/pkg_resources/__init__.py:116: PkgResourcesDeprecationWarning: 0.1.43ubuntu1 is an invalid version and will not be supported in a future release
  warnings.warn(
received 1 prompt(s) and will repeat them 1 times to create 1 images.
Generating 🖼  1/1: " " 512x512px negative-prompt:"Ugly, duplication, duplicates, mutilation, deformed, mutilated, mutation, twisted body, disfigured, bad anatomy, out of frame, extra fingers, mutated hands, poorly drawn hands, extra limbs, malformed limbs, missing arms, extra arms, missing legs, extra legs, mutated hands, extra hands, fused fingers, missing fingers, extra fingers, long neck, small head, closed eyes, rolling eyes, weird eyes, smudged face, blurred face, poorly drawn face, mutation, mutilation, cloned face, strange mouth, grainy, blurred, blurry, writing, calligraphy, signature, text, watermark, bad art," seed:264337829 prompt-strength:7.5 steps:15 sampler-type:k_dpmpp_2m
Loading model /home/dead/.cache/huggingface/hub/models--runwayml--stable-diffusion-v1-5/snapshots/889b629140e71758e1e0006e355c331a5744b4bf/v1-5-pruned-emaonly.ckpt onto cuda backend...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:01<00:00,  4.20it/s]
        ⚠️  Filtering NSFW image. nsfw score: 0.014
    Image Generated. Timings: conditioning:0.24s sampling:1.19s decoding:0.17s safety-filter:4.42s total:6.85s
   Image was unsafe, retrying with new seed...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:01<00:00,  4.24it/s]
    Image Generated. Timings: conditioning:0.02s sampling:1.18s decoding:0.13s safety-filter:1.05s total:2.80s
    [generated] saved to: ./outputs/generated/000000_364337830_kdpmpp2m15_PS7.5_img2img-0.6___[generated].jpg
--mask-prompt: command not found
```

As the command line was interpreted as two separate commands. I remove the stray space in this pull-request, to spare others the headache of finding the whitespace.