### PR TITLE
fix: use entry_points for windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ deploy:  ## Deploy the package to pypi.org
 	git push --tags
 	rm -rf dist
 	python setup.py bdist_wheel
+	python setup.py bdist_wheel --plat-name=win-amd64
 	#python setup.py sdist
 	@echo 'pypi.org Username: '
 	@read username && twine upload --verbose dist/* -u $$username;

--- a/README.md
+++ b/README.md
@@ -298,6 +298,9 @@ docker run -it --gpus all -v $HOME/.cache/huggingface:/root/.cache/huggingface -
 
 ## ChangeLog
 
+**9.0.1**
+- fix: use entry_points for windows since setup.py scripts doesn't work on windows [#239](https://github.com/brycedrennan/imaginAIry/issues/239)
+
 **9.0.0**
 
 - perf: cli now has minimal overhead such that `aimg --help` runs in ~650ms instead of ~3400ms

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,21 @@
+import sys
+
 from setuptools import find_packages, setup
+
+is_for_windows = len(sys.argv) >= 3 and sys.argv[2].startswith("--plat-name=win")
+
+if is_for_windows:
+    scripts = None
+    entry_points = {
+        "console_scripts": [
+            "imagine=imaginairy.cmds:imagine_cmd",
+            "aimg=imaginairy.cmds:aimg",
+        ],
+    }
+else:
+    scripts = ["imaginairy/bin/aimg", "imaginairy/bin/imagine"]
+    entry_points = None
+
 
 with open("README.md", encoding="utf-8") as f:
     readme = f.read()
@@ -16,7 +33,8 @@ setup(
         "Source": "https://github.com/brycedrennan/imaginAIry",
     },
     packages=find_packages(include=("imaginairy", "imaginairy.*")),
-    scripts=["imaginairy/bin/aimg", "imaginairy/bin/imagine"],
+    scripts=scripts,
+    entry_points=entry_points,
     package_data={
         "imaginairy": [
             "configs/*.yaml",


### PR DESCRIPTION
python converts entry_points to exe files so they run on windows.  The scripts that work on linux/macos don't work on windows.