### PR TITLE
fix raw control image processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,8 @@ docker run -it --gpus all -v $HOME/.cache/huggingface:/root/.cache/huggingface -
 
 ## ChangeLog
 
+- fix: filenames start numbers after latest image, even if some previous images were deleted
+
 **11.1.1**
 - fix: fix globbing bug with input image path handling
 - fix: changed sample to True to generate caption using blip model

--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ docker run -it --gpus all -v $HOME/.cache/huggingface:/root/.cache/huggingface -
 
 ## ChangeLog
 
+- fix: raw control images are now properly loaded. fixes #296
 - fix: filenames start numbers after latest image, even if some previous images were deleted
 
 **11.1.1**

--- a/imaginairy/api.py
+++ b/imaginairy/api.py
@@ -34,11 +34,12 @@ def imagine_image_files(
 
     from imaginairy.animations import make_bounce_animation
     from imaginairy.img_utils import pillow_fit_image_within
+    from imaginairy.utils import get_next_filenumber
 
     generated_imgs_path = os.path.join(outdir, "generated")
     os.makedirs(generated_imgs_path, exist_ok=True)
 
-    base_count = len(os.listdir(generated_imgs_path))
+    base_count = get_next_filenumber(generated_imgs_path)
     output_file_extension = output_file_extension.lower()
     if output_file_extension not in {"jpg", "png"}:
         raise ValueError("Must output a png or jpg")

--- a/imaginairy/schema.py
+++ b/imaginairy/schema.py
@@ -172,6 +172,12 @@ class ImaginePrompt:
             if not self.control_image.startswith("*prev."):
                 self.control_image = LazyLoadingImage(filepath=self.control_image)
 
+        if isinstance(self.control_image_raw, str):
+            if not self.control_image_raw.startswith("*prev."):
+                self.control_image_raw = LazyLoadingImage(
+                    filepath=self.control_image_raw
+                )
+
         if isinstance(self.init_image, str):
             if not self.init_image.startswith("*prev."):
                 self.init_image = LazyLoadingImage(filepath=self.init_image)

--- a/imaginairy/utils.py
+++ b/imaginairy/utils.py
@@ -213,3 +213,21 @@ def glob_expand_paths(paths):
         else:
             expanded_paths.extend(glob.glob(os.path.expanduser(p)))
     return expanded_paths
+
+
+def get_next_filenumber(path):
+    """Get the next file number in a directory."""
+    import os
+
+    filenames = os.listdir(path)
+    if not filenames:
+        return 0
+    file_count = len(filenames)
+    filenames.sort()
+    try:
+        last_file_name = filenames[-1]
+        last_file_num = int(last_file_name.split("_")[0])
+    except (ValueError, IndexError):
+        last_file_num = 0
+
+    return max(file_count, last_file_num + 1)


### PR DESCRIPTION
- fix: raw control images are now properly loaded. fixes #296
- fix: filenames start numbers after latest image, even if some previous images were deleted