### PR TITLE
fix: interrupted generations don't prevent more generations

### DIFF
--- a/imaginairy/api/generate.py
+++ b/imaginairy/api/generate.py
@@ -206,6 +206,7 @@ def imagine(
                     progress_img_interval_min_s=progress_img_interval_min_s,
                     add_caption=add_caption,
                     dtype=torch.float16 if half_mode else torch.float32,
+                    output_perf=True,
                 )
                 if not result.safety_score.is_filtered:
                     break

--- a/imaginairy/api/generate_refiners.py
+++ b/imaginairy/api/generate_refiners.py
@@ -431,8 +431,10 @@ def generate_single_image(
         if result.performance_stats:
             log = logger.info if output_perf else logger.debug
             log(f"   Timings: {result.timings_str()}")
-            log(f"   Peak VRAM: {result.gpu_str('memory_peak')}")
-            log(f"   Ending VRAM: {result.gpu_str('memory_end')}")
+            if torch.cuda.is_available():
+                log(f"   Peak VRAM: {result.gpu_str('memory_peak')}")
+                log(f"   Peak VRAM Delta: {result.gpu_str('memory_peak_delta')}")
+                log(f"   Ending VRAM: {result.gpu_str('memory_end')}")
         for controlnet, _ in controlnets:
             controlnet.eject()
         clear_gpu_cache()

--- a/imaginairy/cli/shared.py
+++ b/imaginairy/cli/shared.py
@@ -111,9 +111,9 @@ def _imagine_cmd(
     total_image_count = len(prompt_texts) * max(len(init_images), 1) * repeats
     img_msg = ""
     if len(init_images) > 0:
-        img_msg = f" and {len(init_images)} image(s)"
+        img_msg = f" x {len(init_images)} image(s)"
     logger.info(
-        f"Received {len(prompt_texts)} prompt(s){img_msg}. Will repeat these {repeats} times to create {total_image_count} images.\n"
+        f"Generating {total_image_count} images. ({len(prompt_texts)} prompt(s){img_msg} x {repeats} repetitions)\n"
     )
 
     from imaginairy.api import imagine_image_files

--- a/imaginairy/config.py
+++ b/imaginairy/config.py
@@ -124,7 +124,7 @@ MODEL_WEIGHT_CONFIGS = [
         aliases=MODEL_ARCHITECTURE_LOOKUP["sd15"].aliases,
         architecture=MODEL_ARCHITECTURE_LOOKUP["sd15"],
         defaults={"negative_prompt": DEFAULT_NEGATIVE_PROMPT},
-        weights_location="https://huggingface.co/runwayml/stable-diffusion-v1-5/tree/889b629140e71758e1e0006e355c331a5744b4bf/",
+        weights_location="https://huggingface.co/runwayml/stable-diffusion-v1-5/tree/1d0c4ebf6ff58a5caecab40fa1406526bca4b5b9/",
     ),
     ModelWeightsConfig(
         name="Stable Diffusion 1.5 - Inpainting",

--- a/imaginairy/enhancers/upscale_realesrgan.py
+++ b/imaginairy/enhancers/upscale_realesrgan.py
@@ -31,6 +31,7 @@ def realesrgan_upsampler(tile=512, tile_pad=50, ultrasharp=False):
         tile=tile,
         device=device,
         tile_pad=tile_pad,
+        half=True,
     )
 
     upsampler.device = torch.device(device)

--- a/imaginairy/modules/refiners_sd.py
+++ b/imaginairy/modules/refiners_sd.py
@@ -100,7 +100,7 @@ class StableDiffusion_1(TileModeMixin, RefinerStableDiffusion_1):
         lda: SD1Autoencoder | None = None,
         clip_text_encoder: CLIPTextEncoderL | None = None,
         scheduler: Scheduler | None = None,
-        device: Device | str = "cpu",
+        device: Device | str | None = "cpu",
         dtype: DType = torch.float32,
     ) -> None:
         unet = unet or SD1UNet(in_channels=4)
@@ -124,7 +124,7 @@ class StableDiffusion_1(TileModeMixin, RefinerStableDiffusion_1):
         if dtype is not None:
             to_kwargs["dtype"] = dtype
 
-        self.device = device
+        self.device = device  # type: ignore
         self.dtype = dtype
 
         if to_kwargs:

--- a/imaginairy/utils/log_utils.py
+++ b/imaginairy/utils/log_utils.py
@@ -179,6 +179,9 @@ class ImageLoggingContext:
         self.summary_context.stop()
         self.timing_contexts["total"] = self.summary_context
 
+        # move total to the end
+        self.timing_contexts["total"] = self.timing_contexts.pop("total")
+
         if torch.cuda.is_available():
             self.summary_context.memory_peak = max(
                 max(context.memory_peak, context.memory_start, context.memory_end)

--- a/imaginairy/utils/memory_tracker.py
+++ b/imaginairy/utils/memory_tracker.py
@@ -1,0 +1,43 @@
+import contextlib
+from typing import Callable, List
+
+import torch
+
+
+class TorchRAMTracker(contextlib.ContextDecorator):
+    """Tracks peak CUDA memory usage for a block of code."""
+
+    _memory_stack: List[int] = []
+    mem_interface = torch.cuda
+
+    def __init__(
+        self, name="", callback_fn: "Callable[[TorchRAMTracker], None] | None" = None
+    ):
+        self.name = name
+        self.peak_memory = 0
+        self.start_memory = 0
+        self.end_memory = 0
+        self.callback_fn = callback_fn
+        self._stack_depth = None
+
+    def start(self):
+        current_peak = self.mem_interface.max_memory_allocated()
+        TorchRAMTracker._memory_stack.append(current_peak)
+        self._stack_depth = len(TorchRAMTracker._memory_stack)
+        self.mem_interface.reset_peak_memory_stats()
+        self.start_memory = self.mem_interface.memory_allocated()
+
+    def stop(self):
+        end_peak = self.mem_interface.max_memory_allocated()
+        peaks = TorchRAMTracker._memory_stack[self._stack_depth :] + [end_peak]
+        self.peak_memory = max(peaks)
+        del TorchRAMTracker._memory_stack[self._stack_depth :]
+        self.end_memory = self.mem_interface.memory_allocated()
+        self.peak_memory_delta = self.peak_memory - self.start_memory
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, *exc):
+        self.stop()

--- a/tests/test_utils/test_memory_tracker.py
+++ b/tests/test_utils/test_memory_tracker.py
@@ -1,0 +1,123 @@
+import pytest
+
+from imaginairy.utils.memory_tracker import TorchRAMTracker
+
+
+class MockedMemory:
+    allocated_memory = 0
+    peak_memory = 0
+
+    @classmethod
+    def allocate_memory(cls, amount):
+        cls.allocated_memory += amount
+        cls.peak_memory = max(cls.peak_memory, cls.allocated_memory)
+
+    @classmethod
+    def free_memory(cls, amount):
+        cls.allocated_memory = max(cls.allocated_memory - amount, 0)
+
+    @classmethod
+    def memory_allocated(cls):
+        return cls.allocated_memory
+
+    @classmethod
+    def max_memory_allocated(cls):
+        return cls.peak_memory
+
+    @classmethod
+    def reset_peak_memory_stats(cls):
+        cls.peak_memory = cls.allocated_memory
+
+
+@pytest.fixture()
+def mocked_memory(monkeypatch):
+    monkeypatch.setattr(TorchRAMTracker, "mem_interface", MockedMemory)
+    MockedMemory.allocated_memory = 0
+    MockedMemory.peak_memory = 0
+    return MockedMemory
+
+
+def test_torch_ram_tracker_basic(mocked_memory):
+    with TorchRAMTracker("a") as trt_a:
+        mocked_memory.allocate_memory(1000)
+        mocked_memory.free_memory(1000)
+
+    assert trt_a.peak_memory == 1000
+
+
+def test_torch_ram_tracker_basic_cumulative(mocked_memory):
+    with TorchRAMTracker("a") as trt_a:
+        mocked_memory.allocate_memory(500)
+        mocked_memory.free_memory(100)
+        mocked_memory.allocate_memory(500)
+
+    assert trt_a.peak_memory == 900
+
+
+def test_torch_ram_tracker_nested(mocked_memory):
+    with TorchRAMTracker("a") as trt_a:
+        mocked_memory.allocate_memory(1000)
+        mocked_memory.free_memory(1000)
+        with TorchRAMTracker("b") as trt_b:
+            mocked_memory.allocate_memory(100)
+            mocked_memory.free_memory(100)
+
+    assert trt_a.peak_memory == 1000
+    assert trt_b.peak_memory == 100
+
+
+def test_torch_ram_tracker_nested_b(mocked_memory):
+    with TorchRAMTracker("a") as trt_a:
+        mocked_memory.allocate_memory(100)
+        mocked_memory.free_memory(100)
+        with TorchRAMTracker("b") as trt_b:
+            mocked_memory.allocate_memory(1000)
+            mocked_memory.free_memory(1000)
+
+    assert trt_a.peak_memory == 1000
+    assert trt_b.peak_memory == 1000
+
+
+def test_torch_ram_tracker_nested_deep(mocked_memory):
+    with TorchRAMTracker("a") as trt_a:
+        mocked_memory.allocate_memory(10000)
+        with TorchRAMTracker("b") as trt_b:
+            mocked_memory.free_memory(1000)
+            with TorchRAMTracker("c") as trt_c:
+                mocked_memory.free_memory(1000)
+                with TorchRAMTracker("d") as trt_d:
+                    mocked_memory.free_memory(1000)
+                    with TorchRAMTracker("e") as trt_e:
+                        mocked_memory.free_memory(1000)
+                        with TorchRAMTracker("f") as trt_f:
+                            mocked_memory.free_memory(1000)
+
+    assert trt_a.peak_memory == 10000
+    assert trt_b.peak_memory == 10000
+    assert trt_c.peak_memory == 9000
+    assert trt_d.peak_memory == 8000
+    assert trt_e.peak_memory == 7000
+    assert trt_f.peak_memory == 6000
+
+
+def test_torch_ram_tracker(mocked_memory):
+    with TorchRAMTracker("a") as trt_a:
+        mocked_memory.allocate_memory(1000)  # Spike in block A
+        mocked_memory.free_memory(900)
+        with TorchRAMTracker("b") as trt_b:
+            mocked_memory.allocate_memory(50)  # Operations in block B
+            mocked_memory.free_memory(25)
+        mocked_memory.free_memory(75)
+        mocked_memory.allocate_memory(30)  # More operations in block A/C
+
+    with TorchRAMTracker("c") as trt_c:
+        mocked_memory.allocate_memory(80)  # Operations in another block
+        with TorchRAMTracker("d") as trt_d:
+            mocked_memory.allocate_memory(40)
+        mocked_memory.free_memory(60)
+        mocked_memory.allocate_memory(600)
+
+    assert trt_a.peak_memory == 1000
+    assert trt_b.peak_memory == 150
+    assert trt_c.peak_memory == 740
+    assert trt_d.peak_memory == 200


### PR DESCRIPTION
fixes #424

- pref: improve memory usage when loading SD15.
- feature: clean up CLI output more
- feature: cuda memory tracking context manager
- feature: use safetensors fp16 for sd15